### PR TITLE
Fix navigation logo when switching to mobile

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -50,6 +50,23 @@ describe("Sidebar Navigation", () => {
       // check that text is not rendered
       cy.get("nav").contains("Issues").should("not.exist");
     });
+
+    it("shows large logo after transitioning from desktop to mobile viewport in collapsed state", () => {
+      // collapse navigation
+      cy.get("nav").contains("Collapse").click();
+
+      // change viewport
+      cy.viewport("iphone-8");
+
+      // check that large logo is visible in collapsed state
+      cy.get("header")
+        .find('img[src="/icons/logo-large.svg"]')
+        .should("be.visible");
+
+      cy.get("header")
+        .find('img[src="/icons/logo-small.svg"]')
+        .should("not.be.visible");
+    });
   });
 
   context("mobile resolution", () => {

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -50,8 +50,7 @@
   }
 }
 
-.logoSmall {
-  composes: logo;
+.smallLogo {
   width: 1.4375rem;
   display: none;
 
@@ -62,8 +61,7 @@
   }
 }
 
-.logoLarge {
-  composes: logo;
+.largeLogo {
   width: 7.375rem;
 
   @media (min-width: breakpoint.$desktop) {
@@ -81,6 +79,10 @@
 
 .menuIcon {
   display: block;
+
+  // since converting from img to Image, nextjs requires w/h to be properties of component.
+  // width: space.$s10;
+  // height: space.$s10;
 }
 
 .menuOverlay {

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -18,10 +18,6 @@
   &.isCollapsed {
     @media (min-width: breakpoint.$desktop) {
       width: 5.1875rem;
-
-      .logo {
-        width: 1.4375rem;
-      }
     }
   }
 }
@@ -49,10 +45,31 @@
 }
 
 .logo {
+  @media (min-width: breakpoint.$desktop) {
+    margin: space.$s0 space.$s4;
+  }
+}
+
+.logoSmall {
+  composes: logo;
+  width: 1.4375rem;
+  display: none;
+
+  @media (min-width: breakpoint.$desktop) {
+    &.isCollapsed {
+      display: block;
+    }
+  }
+}
+
+.logoLarge {
+  composes: logo;
   width: 7.375rem;
 
   @media (min-width: breakpoint.$desktop) {
-    margin: space.$s0 space.$s4;
+    &.isCollapsed {
+      display: none;
+    }
   }
 }
 
@@ -64,10 +81,6 @@
 
 .menuIcon {
   display: block;
-
-  // since converting from img to Image, nextjs requires w/h to be properties of component.
-  // width: space.$s10;
-  // height: space.$s10;
 }
 
 .menuOverlay {

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -37,13 +37,21 @@ export function SidebarNavigation() {
         <header className={styles.header}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src={
-              isSidebarCollapsed
-                ? "/icons/logo-small.svg"
-                : "/icons/logo-large.svg"
-            }
+            src={"/icons/logo-small.svg"}
             alt="logo"
-            className={styles.logo}
+            className={classNames(
+              styles.logoSmall,
+              isSidebarCollapsed && styles.isCollapsed,
+            )}
+          />
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={"/icons/logo-large.svg"}
+            alt="logo"
+            className={classNames(
+              styles.logoLarge,
+              isSidebarCollapsed && styles.isCollapsed,
+            )}
           />
           <Button
             onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -40,7 +40,7 @@ export function SidebarNavigation() {
             src={"/icons/logo-small.svg"}
             alt="logo"
             className={classNames(
-              styles.logoSmall,
+              styles.smallLogo,
               isSidebarCollapsed && styles.isCollapsed,
             )}
           />
@@ -49,7 +49,7 @@ export function SidebarNavigation() {
             src={"/icons/logo-large.svg"}
             alt="logo"
             className={classNames(
-              styles.logoLarge,
+              styles.largeLogo,
               isSidebarCollapsed && styles.isCollapsed,
             )}
           />


### PR DESCRIPTION
[- for this tag](https://github.com/profydev/prolog-app-JoshuaCMorgan/blob/15e784bc649b702d553152ab05ebea385c531d94/features/layout/sidebar-navigation/sidebar-navigation.tsx#L39) I changed the means of showing the proper logo.  Instead of a sole dependency upon state of isSideBarCollapsed, I added viewport width.  

To do so, I created two separate img tags, each for separate logo.  Then used CSS to show or hide the appropriate one based upon the viewport width. 

The default logo is "logoLarge".  The only time "logoSmall" shows is when the viewport width is "desktop" and the sidebar is in a collapsed state. 

I created a test that identifies if large logo is visible under two conditions: if sidebar is collapsed and if viewport is mobile view.  I checked the same for small logo being not visible.