### PR TITLE
fix issue list number of events and users

### DIFF
--- a/api/issues.ts
+++ b/api/issues.ts
@@ -12,5 +12,6 @@ export async function getIssues(
     params: { page },
     signal: options?.signal,
   });
+
   return data;
 }

--- a/api/issues.types.ts
+++ b/api/issues.types.ts
@@ -12,4 +12,5 @@ export type Issue = {
   stack: string;
   level: IssueLevel;
   numEvents: number;
+  numUsers: number;
 };

--- a/cypress/e2e/issue-list.cy.ts
+++ b/cypress/e2e/issue-list.cy.ts
@@ -45,10 +45,22 @@ describe("Issue List", () => {
           cy.wrap($el).contains(issue.name);
           cy.wrap($el).contains(issue.message);
           cy.wrap($el).contains(issue.numEvents);
+          cy.wrap($el).contains(issue.numUsers);
           cy.wrap($el).contains(firstLineOfStackTrace);
         });
     });
 
+    it("contains accurate number of events and users for each issue", () => {
+      cy.get("main")
+        .find("tbody")
+        .find("tr")
+        .each(($el, index) => {
+          const issue = mockIssues1.items[index];
+
+          cy.wrap($el).find("td").eq(-2).should("have.text", issue.numEvents);
+          cy.wrap($el).find("td").eq(-1).should("have.text", issue.numUsers);
+        });
+    });
     it("paginates the data", () => {
       // test first page
       cy.contains("Page 1 of 3");

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -17,7 +17,7 @@ const levelColors = {
 };
 
 export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
-  const { name, message, stack, level, numEvents } = issue;
+  const { name, message, stack, level, numEvents, numUsers } = issue;
   const firstLineOfStackTrace = stack.split("\n")[1];
 
   return (
@@ -43,7 +43,7 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
         </Badge>
       </td>
       <td className={styles.cell}>{numEvents}</td>
-      <td className={styles.cell}>{numEvents}</td>
+      <td className={styles.cell}>{numUsers}</td>
     </tr>
   );
 }


### PR DESCRIPTION
the number of users was missing from data extraction when making the API call.
`const { name, message, stack, level, numEvents } = issue;` [link to source code](https://github.com/profydev/prolog-app-JoshuaCMorgan/blob/aeab48af0cbc78601c1b5ec47a3c10704d03d58e/features/issues/components/issue-list/issue-row.tsx#L20)

It was added to the extracted items and then applied appropriately to the 'issue row' component.  A type was also created.

The test for 'renders the issues" had `numIssues` added to accommodate the missing item.
An additional test was added to check that each issues' number of users and number of errors matches the incoming data. Mock data was used. This is done for the first page only.  
